### PR TITLE
Fix overflow on 32-bit platforms.

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -21,6 +21,7 @@
 package pool
 
 import (
+	"math"
 	"math/bits"
 	"sync"
 )
@@ -29,7 +30,7 @@ import (
 var GlobalPool = new(BufferPool)
 
 // MaxLength is the maximum length of an element that can be added to the Pool.
-const MaxLength = 1 << 32
+const MaxLength = math.MaxInt32
 
 // BufferPool is a pool to handle cases of reusing elements of varying sizes. It
 // maintains 32 internal pools, for each power of 2 in 0-32.


### PR DESCRIPTION
This fixes a compile error in 32-bit platforms:
```
# github.com/libp2p/go-buffer-pool
./pool.go:55:12: constant 4294967296 overflows int
./pool.go:68:31: constant 4294967296 overflows int
```
Tested using `go version go1.10.4 linux/386`.

Closes #1 

CC @Stebalien 