### PR TITLE
test: fix gc test on go 1.16

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -82,6 +82,8 @@ func TestPool(t *testing.T) {
 
 	debug.SetGCPercent(100) // to allow following GC to actually run
 	runtime.GC()
+	// For some reason, you need to run GC twice on go 1.16 if you want it to reliably work.
+	runtime.GC()
 	if g := p.Get(10); &g[0] == &a[0] {
 		t.Fatalf("got a; want new slice after GC")
 	}


### PR DESCRIPTION
No idea why we need this, but go 1.16 doesn't always completely GC the first round.